### PR TITLE
Potential fix for code scanning alert no. 99: Useless assignment to local variable

### DIFF
--- a/dist/ha-card-weather-conditions.js
+++ b/dist/ha-card-weather-conditions.js
@@ -226,7 +226,7 @@ class b extends HTMLElement {
     try {
       t = this.shouldUpdate(e), t ? (this.willUpdate(e), this._$EO?.forEach((s) => s.hostUpdate?.()), this.update(e)) : this._$EU();
     } catch (s) {
-      throw t = !1, this._$EU(), s;
+      throw this._$EU(), s;
     }
     t && this._$AE(e);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/PatrickSt1991/ha-card-weather-conditions-2025/security/code-scanning/99](https://github.com/PatrickSt1991/ha-card-weather-conditions-2025/security/code-scanning/99)

To fix the problem, we need to remove the redundant assignment to the variable `t` on line 229. This will clean up the code and eliminate the useless assignment without changing the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
